### PR TITLE
Fix Python syntax error by adding a colon (:)

### DIFF
--- a/Applications/Merge Multiple PDF/source-code.py
+++ b/Applications/Merge Multiple PDF/source-code.py
@@ -3,13 +3,12 @@ import os
 #var = os.getcwd() For extracting from enother folder
 merger = PdfFileMerger()
 for items in os.listdir():
-  if items.endswith('.pdf')
+  if items.endswith('.pdf'):
     merger.append(items)
 merger.write("Final_pdf.pdf")
 merger = PdfFileMerger()
-fin = file(originalFile, 'rb')
-merger.append(PdfFileReader(fin))
-fin.close()
+with open(originalFile, 'rb') as fin:
+    merger.append(PdfFileReader(fin))
 os.remove(originalFile)
 merger.close()
 


### PR DESCRIPTION
Also, `file()` was removed from Python on 1/1/2020 so use `open()` instead.

[flake8](http://flake8.pycqa.org) testing of https://github.com/qxresearch/qxresearch-event-1 on Python 3.9.0rc2+

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./Applications/Merge Multiple PDF/source-code.py:6:27: E999 SyntaxError: invalid syntax
  if items.endswith('.pdf')
                          ^
./Applications/Terminal Tricks/source-code-funky.py:1:1: E902 IndentationError: unindent does not match any outer indentation level

./Applications/Terminal Tricks/source-code-color.py:11:1: E999 SyntaxError: invalid syntax
^
1     E902 IndentationError: unindent does not match any outer indentation level
2     E999 SyntaxError: invalid syntax
3
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.