### PR TITLE
Fixed 2 Errors in Merge PDF Files

### DIFF
--- a/Applications/Merge Multiple PDF/source-code.py
+++ b/Applications/Merge Multiple PDF/source-code.py
@@ -1,4 +1,4 @@
-from PyPDF2 import PdfFileMerger
+from PyPDF4 import PdfFileMerger
 import os 
 #var = os.getcwd() For extracting from enother folder
 merger = PdfFileMerger()
@@ -6,9 +6,8 @@ for items in os.listdir():
   if items.endswith('.pdf'):
     merger.append(items)
 merger.write("Final_pdf.pdf")
-merger = PdfFileMerger()
-with open(originalFile, 'rb') as fin:
-    merger.append(PdfFileReader(fin))
-os.remove(originalFile)
 merger.close()
 
+for items in os.listdir():
+  if items != ( 'Final_pdf.pdf') and items.endswith('.pdf'):
+    os.remove(items)


### PR DESCRIPTION
Closes https://github.com/qxresearch/qxresearch-event-1/issues/36

Error 1 :
 PdfFileMerger is removed from PyPDF2 that's why an error was showing

Error 2 :
 As to the README.md file after running the code  all singles pdf files should be deleted but while running the code files were not being deleted whether throwing this error :  
![{88D85059-145C-4E46-817F-594188D7AD8F}](https://user-images.githubusercontent.com/95538354/229375395-9070d3ac-d16b-46ca-a6f0-c9943ed49638.png)
 
  In this new code all these 2 issues are solved .




